### PR TITLE
fix: adjust old ios not compatible bird image

### DIFF
--- a/Projects/Detail/Sources/View/DetailHeaderView.swift
+++ b/Projects/Detail/Sources/View/DetailHeaderView.swift
@@ -100,7 +100,11 @@ final class DetailHeaderView: UIView {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
         let config = UIImage.SymbolConfiguration(pointSize: 18)
-        button.setImage(UIImage(systemName: "bird.fill", withConfiguration: config), for: .normal)
+        if #available(iOS 16.0, *) {
+            button.setImage(UIImage(systemName: "bird.fill", withConfiguration: config), for: .normal)
+        } else {
+            button.setImage(UIImage(systemName: "bubble.left", withConfiguration: config), for: .normal)
+        }
         button.tintColor = .white
         button.backgroundColor = .systemBlue
         button.layer.cornerRadius = 18


### PR DESCRIPTION
## Description
- Adjust iOS 16 lower version who don't have bird.fill sf symbol

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Test update

###
|<img width="250" alt="Simulator Screenshot - iPhone 13 - 2026-02-10 at 08 15 14" src="https://github.com/user-attachments/assets/cb22d23b-83ce-444f-847e-31d89395b5d2" />|<img width="250" alt="Simulator Screenshot - iPhone 13 - 2026-02-10 at 08 14 38" src="https://github.com/user-attachments/assets/ba7fca54-8e2f-4d82-80a2-6af788047f2d" />|
|:-:|:-:|
|bug|fix|